### PR TITLE
[Fix]: Render inner property keys

### DIFF
--- a/src/components/Schemas/components/SchemaDetails.jsx
+++ b/src/components/Schemas/components/SchemaDetails.jsx
@@ -57,7 +57,7 @@ function SchemaProperty({ properties, required }) {
         if (typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {
           return (
             <div key={fieldKey}>
-              <PropertyField field={propertyKeys[fieldKey]} value={''} />
+              <PropertyField field={fieldKey} value={''} />
               <div className='margin-left--md'>
                 {Object.entries(fieldValue).map(renderPropertyField)}
               </div>
@@ -68,7 +68,7 @@ function SchemaProperty({ properties, required }) {
         if (Array.isArray(fieldValue)) {
           return (
             <div key={fieldKey}>
-              <PropertyField field={propertyKeys[fieldKey]} value={''} />
+              <PropertyField field={fieldKey} value={''} />
               <div className='margin-left--md'>
                 {fieldValue
                   .map((value, index) => [index + 1, value])

--- a/src/components/Schemas/components/SchemaDetails.jsx
+++ b/src/components/Schemas/components/SchemaDetails.jsx
@@ -28,7 +28,7 @@ function PropertyField({ field, value }) {
 
   return (
     <strong>
-      <span className='text--capitalize'>{prettyField(field)}:</span>
+      <span>{field}:</span>
       <span className='margin-left--sm'>{renderValue()}</span>
     </strong>
   );
@@ -53,13 +53,48 @@ function SchemaProperty({ properties, required }) {
       const propertyKeys = keysLiteral(property);
       const isRequired = (required || []).includes(key);
 
+      const renderPropertyField = ([fieldKey, fieldValue]) => {
+        if (typeof fieldValue === 'object' && !Array.isArray(fieldValue)) {
+          return (
+            <div key={fieldKey}>
+              <PropertyField field={propertyKeys[fieldKey]} value={''} />
+              <div className='margin-left--md'>
+                {Object.entries(fieldValue).map(renderPropertyField)}
+              </div>
+            </div>
+          );
+        }
+
+        if (Array.isArray(fieldValue)) {
+          return (
+            <div key={fieldKey}>
+              <PropertyField field={propertyKeys[fieldKey]} value={''} />
+              <div className='margin-left--md'>
+                {fieldValue
+                  .map((value, index) => [index + 1, value])
+                  .map(renderPropertyField)}
+              </div>
+            </div>
+          );
+        }
+
+        return (
+          <div key={fieldKey}>
+            <PropertyField
+              field={propertyKeys[fieldKey] ?? fieldKey}
+              value={JSON.stringify(fieldValue)}
+            />
+          </div>
+        );
+      };
+
       return (
         <div
           key={key}
           className={`${styles['property-field']} table-of-contents__left-border padding-left--lg`}
         >
           <h6 className={styles['property-title']}>
-            <span>{prettyField(key)}</span>
+            <span>{key}</span>
             {' - '}
             <i className='text--primary'>
               {isRequired ? 'Required' : 'Optional'}
@@ -68,16 +103,7 @@ function SchemaProperty({ properties, required }) {
           <div
             className={`${styles.properties} table-of-contents__left-border`}
           >
-            {Object.entries(property).map(([fieldKey, fieldValue]) => {
-              return (
-                <div key={fieldKey}>
-                  <PropertyField
-                    field={propertyKeys[fieldKey]}
-                    value={JSON.stringify(fieldValue)}
-                  />
-                </div>
-              );
-            })}
+            {Object.entries(property).map(renderPropertyField)}
           </div>
         </div>
       );


### PR DESCRIPTION
[Ticket](https://trello.com/c/qLkPxGcG/6174-improve-readability-for-example-property-in-schema-library)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
This PR removes the property keys that was being used to make property names pretty but for inner keys.

## Changes
- updated schema details

## Testing
Tested locally against all credentials.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects